### PR TITLE
[codex] fix embedding server URL configuration

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,6 +26,12 @@ pnpm test:db:seed:token   # against the token server
 pnpm test:db:seed:basic   # against the basic-auth server
 ```
 
+The seed data includes:
+
+- `articles` and `code_snippets` with small 8-dimensional fixture embeddings.
+- `huggingface_384d` with HuggingFace-style 384-dimensional fixture embeddings
+  for testing inferred collection dimensions and custom embedding server URLs.
+
 Stop with `Ctrl+C`.
 
 ## Auth credentials

--- a/scripts/seed-test-db.mjs
+++ b/scripts/seed-test-db.mjs
@@ -27,13 +27,11 @@ if (authMode === 'token') {
 
 const client = new ChromaClient({ host: 'localhost', port, ssl: false, headers })
 
-const EMBED_DIM = 8
-
-function seededVector(seed) {
+function seededVector(seed, dimension) {
   // Deterministic pseudo-random vector so re-seeds produce stable embeddings.
-  const out = new Array(EMBED_DIM)
+  const out = new Array(dimension)
   let s = seed
-  for (let i = 0; i < EMBED_DIM; i++) {
+  for (let i = 0; i < dimension; i++) {
     s = (s * 9301 + 49297) % 233280
     out[i] = s / 233280 - 0.5
   }
@@ -43,6 +41,7 @@ function seededVector(seed) {
 const collections = [
   {
     name: 'articles',
+    dimension: 8,
     metadata: { description: 'Sample blog articles for explorer testing' },
     docs: [
       { id: 'a1', document: 'Getting started with vector databases.', metadata: { topic: 'intro', words: 5 } },
@@ -54,6 +53,7 @@ const collections = [
   },
   {
     name: 'code_snippets',
+    dimension: 8,
     metadata: { description: 'Code snippets across languages' },
     docs: [
       { id: 'c1', document: 'def hello():\n    print("hi")', metadata: { language: 'python', lines: 2 } },
@@ -61,6 +61,32 @@ const collections = [
       { id: 'c3', document: 'fn main() { println!("hi"); }', metadata: { language: 'rust', lines: 1 } },
       { id: 'c4', document: 'package main\nfunc main() {}', metadata: { language: 'go', lines: 2 } },
       { id: 'c5', document: 'puts "hello"', metadata: { language: 'ruby', lines: 1 } },
+    ],
+  },
+  {
+    name: 'huggingface_384d',
+    dimension: 384,
+    metadata: {
+      description: 'HuggingFace-style 384-dimensional embeddings for URL and dimension testing',
+      embedding_provider: 'huggingface-server',
+      embedding_model: 'sentence-transformers/all-MiniLM-L6-v2',
+    },
+    docs: [
+      {
+        id: 'hf1',
+        document: 'A local HuggingFace embedding server can expose sentence-transformer vectors.',
+        metadata: { provider: 'huggingface-server', model: 'all-MiniLM-L6-v2', dimension: 384 },
+      },
+      {
+        id: 'hf2',
+        document: 'MiniLM embeddings are compact enough for fast document exploration.',
+        metadata: { provider: 'huggingface-server', model: 'all-MiniLM-L6-v2', dimension: 384 },
+      },
+      {
+        id: 'hf3',
+        document: 'This fixture helps verify inferred dimensions in the collection UI.',
+        metadata: { provider: 'huggingface-server', model: 'all-MiniLM-L6-v2', dimension: 384 },
+      },
     ],
   },
 ]
@@ -76,9 +102,9 @@ async function main() {
     const ids = spec.docs.map((d) => d.id)
     const documents = spec.docs.map((d) => d.document)
     const metadatas = spec.docs.map((d) => d.metadata)
-    const embeddings = spec.docs.map((_, idx) => seededVector(seedBase + idx + 1))
+    const embeddings = spec.docs.map((_, idx) => seededVector(seedBase + idx + 1, spec.dimension))
     await col.upsert({ ids, documents, metadatas, embeddings })
-    console.log(`[seed] upserted ${ids.length} docs into "${spec.name}"`)
+    console.log(`[seed] upserted ${ids.length} docs into "${spec.name}" (${spec.dimension}d)`)
   }
 
   console.log('[seed] done')

--- a/src/components/collections/CollectionConfigView.tsx
+++ b/src/components/collections/CollectionConfigView.tsx
@@ -3,7 +3,16 @@ import { ChevronDown, ChevronRight, Plus, X } from 'lucide-react'
 import { useDraftCollection, DraftHNSWConfig } from '../../context/DraftCollectionContext'
 import { useChromaDB } from '../../providers/ChromaDBProvider'
 import { useCollection } from '../../context/CollectionContext'
-import { EMBEDDING_FUNCTIONS, EMBEDDING_FUNCTION_GROUPS, getEmbeddingFunctionById } from '../../constants/embedding-functions'
+import {
+  buildEmbeddingFunctionOverride,
+  EMBEDDING_FUNCTIONS,
+  EMBEDDING_FUNCTION_GROUPS,
+  embeddingFunctionUsesUrl,
+  getEmbeddingFunctionById,
+  getEmbeddingFunctionUrlLabel,
+  getEmbeddingFunctionUrlPlaceholder,
+  validateEmbeddingFunctionUrl,
+} from '../../constants/embedding-functions'
 import { MetadataValueType, validateMetadataValue } from '../../types/metadata'
 import { CopyProgressDialog } from './CopyProgressDialog'
 
@@ -29,19 +38,19 @@ export function CollectionConfigView() {
   })
 
   const selectedEf = draftCollection ? getEmbeddingFunctionById(draftCollection.embeddingFunctionId) : EMBEDDING_FUNCTIONS[0]
+  const embeddingFunctionUrlError = draftCollection && selectedEf
+    ? validateEmbeddingFunctionUrl(selectedEf, draftCollection.embeddingFunctionUrl)
+    : null
+  const dimensionsLabel = selectedEf?.dimensions ? `${selectedEf.dimensions}d` : 'Inferred from first embedding'
 
   // Handle embedding function change - auto-populate dimension
   const handleEfChange = useCallback(
     (efId: string) => {
-      updateDraft({ embeddingFunctionId: efId, dimensionOverride: '' })
-    },
-    [updateDraft]
-  )
-
-  // Handle dimension override change
-  const handleDimensionChange = useCallback(
-    (value: string) => {
-      updateDraft({ dimensionOverride: value })
+      const nextEf = getEmbeddingFunctionById(efId)
+      updateDraft({
+        embeddingFunctionId: efId,
+        embeddingFunctionUrl: nextEf?.url || '',
+      })
     },
     [updateDraft]
   )
@@ -70,13 +79,16 @@ export function CollectionConfigView() {
     if (!draftCollection?.sourceCollection) return false
 
     const source = draftCollection.sourceCollection
-    const sourceType = source.embeddingFunction?.name === 'openai' ? 'openai' : 'default'
+    const sourceType = source.embeddingFunction?.name ?? 'default'
     const sourceModel = source.embeddingFunction?.config?.model_name as string | undefined
+    const sourceUrl = source.embeddingFunction?.config?.url as string | undefined
 
     const draftEf = getEmbeddingFunctionById(draftCollection.embeddingFunctionId)
+    const draftUrl = draftCollection.embeddingFunctionUrl.trim() || draftEf?.url
 
     if (draftEf?.type !== sourceType) return true
-    if (draftEf?.type === 'openai' && draftEf?.modelName !== sourceModel) return true
+    if (sourceModel && draftEf?.modelName !== sourceModel) return true
+    if (draftUrl !== sourceUrl) return true
 
     return false
   }, [draftCollection])
@@ -88,6 +100,11 @@ export function CollectionConfigView() {
     const errors: Record<string, string> = {}
     if (!draftCollection.name.trim()) {
       errors.name = 'Collection name is required'
+    }
+    const draftEf = getEmbeddingFunctionById(draftCollection.embeddingFunctionId)
+    const urlError = validateEmbeddingFunctionUrl(draftEf, draftCollection.embeddingFunctionUrl)
+    if (urlError) {
+      errors.embeddingFunctionUrl = urlError
     }
 
     if (Object.keys(errors).length > 0) {
@@ -132,10 +149,9 @@ export function CollectionConfigView() {
       const result = await window.electronAPI.chromadb.copyCollection(currentProfile.id, {
         sourceCollectionName: draftCollection.sourceCollection.name,
         targetName: draftCollection.name.trim(),
-        embeddingFunction: draftEf ? {
-          type: draftEf.type,
-          modelName: draftEf.modelName,
-        } : undefined,
+        embeddingFunction: draftEf
+          ? buildEmbeddingFunctionOverride(draftEf, { url: draftCollection.embeddingFunctionUrl })
+          : undefined,
         hnsw: Object.keys(hnswConfig).length > 0 ? hnswConfig : undefined,
         regenerateEmbeddings: needsEmbeddingRegeneration(),
       })
@@ -283,22 +299,40 @@ export function CollectionConfigView() {
           {selectedEf && <p className="text-[10px] text-muted-foreground">{selectedEf.modelName}</p>}
         </div>
 
-        {/* Dimension Input */}
+        {embeddingFunctionUsesUrl(selectedEf) && (
+          <div className="space-y-1">
+            <label htmlFor="ef-url" className="text-[11px] font-medium text-muted-foreground">
+              {getEmbeddingFunctionUrlLabel(selectedEf)}
+            </label>
+            <input
+              id="ef-url"
+              type="url"
+              value={draftCollection.embeddingFunctionUrl}
+              onChange={(e) => updateDraft({ embeddingFunctionUrl: e.target.value })}
+              placeholder={getEmbeddingFunctionUrlPlaceholder(selectedEf)}
+              className={`${inputClassName} ${embeddingFunctionUrlError ? 'border-destructive' : ''}`}
+              style={inputStyle}
+            />
+            {embeddingFunctionUrlError ? (
+              <p className="text-[10px] text-destructive">{embeddingFunctionUrlError}</p>
+            ) : (
+              <p className="text-[10px] text-muted-foreground">
+                Used by the client when generating embeddings.
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Dimension Info */}
         <div className="space-y-1">
-          <label htmlFor="dimension" className="text-[11px] font-medium text-muted-foreground">
-            Dimension
-          </label>
-          <input
-            id="dimension"
-            type="number"
-            value={draftCollection.dimensionOverride || ''}
-            onChange={(e) => handleDimensionChange(e.target.value)}
-            placeholder={selectedEf?.dimensions?.toString() || 'auto'}
-            className={inputClassName}
-            style={inputStyle}
-          />
+          <span className="text-[11px] font-medium text-muted-foreground">
+            Dimensions
+          </span>
+          <p className="h-6 flex items-center text-[11px] px-1.5 rounded-md bg-muted/40 text-foreground/70">
+            {dimensionsLabel}
+          </p>
           <p className="text-[10px] text-muted-foreground">
-            Default: {selectedEf?.dimensions ?? 'auto'}
+            Chroma sets the collection dimension from generated embeddings.
           </p>
         </div>
 
@@ -586,7 +620,7 @@ export function CollectionConfigView() {
             <button
               type="button"
               onClick={handleCopyCollection}
-              disabled={isCopying || !draftCollection.name.trim()}
+              disabled={isCopying || !draftCollection.name.trim() || Boolean(embeddingFunctionUrlError)}
               className="h-6 px-2 text-[11px] rounded-md bg-[#007AFF] hover:bg-[#0071E3] active:bg-[#006DD9] text-white disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isCopying ? 'Copying…' : 'Copy Collection'}
@@ -595,7 +629,7 @@ export function CollectionConfigView() {
             <button
               type="button"
               onClick={saveDraft}
-              disabled={isCreating || !draftCollection.name.trim()}
+              disabled={isCreating || !draftCollection.name.trim() || Boolean(embeddingFunctionUrlError)}
               className="h-6 px-2 text-[11px] rounded-md bg-[#007AFF] hover:bg-[#0071E3] active:bg-[#006DD9] text-white disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isCreating ? 'Creating…' : 'Create'}

--- a/src/components/documents/EmbeddingFunctionSelector.tsx
+++ b/src/components/documents/EmbeddingFunctionSelector.tsx
@@ -3,7 +3,16 @@ import { ChevronDown } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
-import { EMBEDDING_FUNCTIONS, EMBEDDING_FUNCTION_GROUPS } from '../../constants/embedding-functions'
+import {
+  buildEmbeddingFunctionOverride,
+  EMBEDDING_FUNCTIONS,
+  EMBEDDING_FUNCTION_GROUPS,
+  embeddingFunctionUsesUrl,
+  getEmbeddingFunctionById,
+  getEmbeddingFunctionUrlLabel,
+  getEmbeddingFunctionUrlPlaceholder,
+  validateEmbeddingFunctionUrl,
+} from '../../constants/embedding-functions'
 
 interface EmbeddingFunctionSelectorProps {
   collectionName: string
@@ -83,30 +92,36 @@ export function EmbeddingFunctionSelector({
 }: EmbeddingFunctionSelectorProps) {
   const [open, setOpen] = useState(false)
   const [selectedId, setSelectedId] = useState(() => getSelectedEmbeddingId(currentOverride))
+  const [customUrl, setCustomUrl] = useState(currentOverride?.url || '')
   const [saving, setSaving] = useState(false)
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (nextOpen) {
-      setSelectedId(getSelectedEmbeddingId(currentOverride))
+      const nextSelectedId = getSelectedEmbeddingId(currentOverride)
+      const nextSelectedEF = getEmbeddingFunctionById(nextSelectedId)
+      setSelectedId(nextSelectedId)
+      setCustomUrl(currentOverride?.url || nextSelectedEF?.url || '')
     }
     setOpen(nextOpen)
   }
 
   const selectedEF = EMBEDDING_FUNCTIONS.find(ef => ef.id === selectedId)
+  const urlError = validateEmbeddingFunctionUrl(selectedEF, customUrl)
 
   const serverFunction = EMBEDDING_FUNCTIONS.find(ef => ef.modelName === serverConfig?.config?.model_name)
 
+  const handleSelectedIdChange = (nextSelectedId: string) => {
+    const nextSelectedEF = getEmbeddingFunctionById(nextSelectedId)
+    setSelectedId(nextSelectedId)
+    setCustomUrl(nextSelectedEF?.url || '')
+  }
+
   const handleSave = async () => {
-    if (!selectedEF) return
+    if (!selectedEF || urlError) return
 
     setSaving(true)
     try {
-      await onSave({
-        type: selectedEF.type,
-        modelName: selectedEF.modelName,
-        url: selectedEF.url,
-        accountId: selectedEF.accountId,
-      })
+      await onSave(buildEmbeddingFunctionOverride(selectedEF, { url: customUrl }))
       setOpen(false)
     } finally {
       setSaving(false)
@@ -166,7 +181,7 @@ export function EmbeddingFunctionSelector({
               <select
                 id="ef-select"
                 value={selectedId}
-                onChange={(e) => setSelectedId(e.target.value)}
+                onChange={(e) => handleSelectedIdChange(e.target.value)}
                 className="w-full h-[22px] appearance-none rounded-[5px] border-none bg-white/10 dark:bg-white/5 pl-2 pr-6 text-[13px] text-foreground shadow-[0_0.5px_1px_rgba(0,0,0,0.1),inset_0_0.5px_0.5px_rgba(255,255,255,0.1)] ring-1 ring-black/10 dark:ring-white/10 focus:outline-none focus:ring-2 focus:ring-primary/50 cursor-default"
               >
                 <option value="">Select…</option>
@@ -183,6 +198,27 @@ export function EmbeddingFunctionSelector({
               <ChevronDown className="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 size-3 text-muted-foreground/70" />
             </div>
           </div>
+
+          {embeddingFunctionUsesUrl(selectedEF) && (
+            <div className="px-1 space-y-1.5">
+              <Label htmlFor="ef-url" className="text-[11px] font-normal">
+                {getEmbeddingFunctionUrlLabel(selectedEF)}
+              </Label>
+              <input
+                id="ef-url"
+                type="url"
+                value={customUrl}
+                onChange={(e) => setCustomUrl(e.target.value)}
+                placeholder={getEmbeddingFunctionUrlPlaceholder(selectedEF)}
+                className={`w-full h-[22px] rounded-[5px] border-none bg-white/10 dark:bg-white/5 px-2 text-[12px] text-foreground placeholder:text-muted-foreground/60 shadow-[0_0.5px_1px_rgba(0,0,0,0.1),inset_0_0.5px_0.5px_rgba(255,255,255,0.1)] ring-1 focus:outline-none focus:ring-2 ${
+                  urlError
+                    ? 'ring-destructive/50 focus:ring-destructive/50'
+                    : 'ring-black/10 dark:ring-white/10 focus:ring-primary/50'
+                }`}
+              />
+              {urlError && <p className="text-[10px] text-destructive">{urlError}</p>}
+            </div>
+          )}
 
           {/* Selected info */}
           {(() => {
@@ -218,6 +254,9 @@ export function EmbeddingFunctionSelector({
                 <p className="text-muted-foreground"><span className="text-foreground/60">Type:</span> {displayEF.type}</p>
                 <p className="text-muted-foreground"><span className="text-foreground/60">Model:</span> {displayEF.modelName}</p>
                 <p className="text-muted-foreground"><span className="text-foreground/60">Dimensions:</span> {displayEF.dimensions ?? 'variable'}</p>
+                {embeddingFunctionUsesUrl(selectedEF) && customUrl.trim() && !urlError && (
+                  <p className="text-muted-foreground break-all"><span className="text-foreground/60">URL:</span> {customUrl.trim()}</p>
+                )}
                 {embeddingDimension && (
                   <p className="text-muted-foreground pt-1 border-t border-black/5 dark:border-white/5 mt-1">
                     <span className="text-foreground/60">Collection:</span> {embeddingDimension}d
@@ -245,7 +284,7 @@ export function EmbeddingFunctionSelector({
             size="sm"
             className="h-7 text-[12px] px-3"
             onClick={handleSave}
-            disabled={!selectedEF || saving}
+            disabled={!selectedEF || saving || Boolean(urlError)}
           >
             {saving ? 'Saving…' : 'Apply'}
           </Button>

--- a/src/constants/embedding-functions.ts
+++ b/src/constants/embedding-functions.ts
@@ -1,3 +1,5 @@
+import type { EmbeddingFunctionOverride } from '../types/electron'
+
 export type EmbeddingFunctionType =
   | 'default'
   | 'openai'
@@ -23,6 +25,59 @@ export interface EmbeddingFunctionConfig {
   url?: string // For Ollama, HuggingFace Server
   accountId?: string // For Cloudflare Workers AI
   group: string // For UI grouping
+}
+
+export function embeddingFunctionUsesUrl(ef: Pick<EmbeddingFunctionConfig, 'type'> | undefined): boolean {
+  return ef?.type === 'ollama' || ef?.type === 'huggingface-server'
+}
+
+export function embeddingFunctionRequiresUrl(ef: Pick<EmbeddingFunctionConfig, 'type'> | undefined): boolean {
+  return ef?.type === 'huggingface-server'
+}
+
+export function getEmbeddingFunctionUrlLabel(ef: Pick<EmbeddingFunctionConfig, 'type'> | undefined): string {
+  return ef?.type === 'huggingface-server' ? 'Server URL' : 'URL'
+}
+
+export function getEmbeddingFunctionUrlPlaceholder(ef: Pick<EmbeddingFunctionConfig, 'type'> | undefined): string {
+  return ef?.type === 'huggingface-server' ? 'https://your-embedding-server.example.com' : 'http://localhost:11434'
+}
+
+export function validateEmbeddingFunctionUrl(
+  ef: Pick<EmbeddingFunctionConfig, 'type'> | undefined,
+  value: string
+): string | null {
+  if (!embeddingFunctionUsesUrl(ef)) return null
+
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return embeddingFunctionRequiresUrl(ef) ? `${getEmbeddingFunctionUrlLabel(ef)} is required` : null
+  }
+
+  try {
+    const parsed = new URL(trimmed)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return `${getEmbeddingFunctionUrlLabel(ef)} must use http or https`
+    }
+  } catch {
+    return `${getEmbeddingFunctionUrlLabel(ef)} must be a valid URL`
+  }
+
+  return null
+}
+
+export function buildEmbeddingFunctionOverride(
+  ef: EmbeddingFunctionConfig,
+  options: { url?: string } = {}
+): EmbeddingFunctionOverride {
+  const url = options.url?.trim() || ef.url
+
+  return {
+    type: ef.type,
+    modelName: ef.modelName,
+    url: url || undefined,
+    accountId: ef.accountId,
+  }
 }
 
 export const EMBEDDING_FUNCTIONS: EmbeddingFunctionConfig[] = [

--- a/src/context/DraftCollectionContext.tsx
+++ b/src/context/DraftCollectionContext.tsx
@@ -2,7 +2,11 @@ import { createContext, useContext, useState, useCallback, ReactNode } from 'rea
 import { useChromaDB } from '../providers/ChromaDBProvider'
 import { useCreateCollectionMutation } from '../hooks/useChromaQueries'
 import { useCollection } from './CollectionContext'
-import { EMBEDDING_FUNCTIONS } from '../constants/embedding-functions'
+import {
+  buildEmbeddingFunctionOverride,
+  EMBEDDING_FUNCTIONS,
+  validateEmbeddingFunctionUrl,
+} from '../constants/embedding-functions'
 import { TypedMetadataRecord, typedMetadataToChromaFormat, validateMetadataValue } from '../types/metadata'
 
 export interface DraftHNSWConfig {
@@ -14,7 +18,7 @@ export interface DraftHNSWConfig {
 export interface DraftCollection {
   name: string
   embeddingFunctionId: string
-  dimensionOverride: string // String to allow empty input for auto
+  embeddingFunctionUrl: string
   hnsw: DraftHNSWConfig
   // Optional first document (metadata here defines the collection's schema)
   firstDocument: {
@@ -52,7 +56,7 @@ function createInitialDraft(): DraftCollection {
   return {
     name: '',
     embeddingFunctionId: DEFAULT_EF.id,
-    dimensionOverride: '',
+    embeddingFunctionUrl: DEFAULT_EF.url || '',
     hnsw: {
       space: 'l2',
       efConstruction: '',
@@ -81,9 +85,11 @@ export function DraftCollectionProvider({ children }: DraftCollectionProviderPro
   const startCopyFromCollection = useCallback((collection: CollectionInfo) => {
     // Find matching embedding function from collection's config
     let embeddingFunctionId: string = DEFAULT_EF.id
+    let embeddingFunctionUrl = DEFAULT_EF.url || ''
     if (collection.embeddingFunction) {
-      const efType = collection.embeddingFunction.name === 'openai' ? 'openai' : 'default'
+      const efType = collection.embeddingFunction.name
       const efModelName = collection.embeddingFunction.config?.model_name as string | undefined
+      const efUrl = collection.embeddingFunction.config?.url as string | undefined
 
       // Try to find exact match
       const matchingEf = EMBEDDING_FUNCTIONS.find(
@@ -98,6 +104,9 @@ export function DraftCollectionProvider({ children }: DraftCollectionProviderPro
           embeddingFunctionId = typeMatch.id
         }
       }
+
+      const selectedEf = EMBEDDING_FUNCTIONS.find((ef) => ef.id === embeddingFunctionId) || DEFAULT_EF
+      embeddingFunctionUrl = efUrl || selectedEf.url || ''
     }
 
     // Extract HNSW config from collection metadata
@@ -121,7 +130,7 @@ export function DraftCollectionProvider({ children }: DraftCollectionProviderPro
     setDraftCollection({
       name: `${collection.name}-copy`,
       embeddingFunctionId,
-      dimensionOverride: '',
+      embeddingFunctionUrl,
       hnsw,
       firstDocument: null,
       sourceCollection: collection,
@@ -139,6 +148,12 @@ export function DraftCollectionProvider({ children }: DraftCollectionProviderPro
     if (updates.name !== undefined) {
       setValidationErrors((prev) => {
         const { name, ...rest } = prev
+        return rest
+      })
+    }
+    if (updates.embeddingFunctionUrl !== undefined || updates.embeddingFunctionId !== undefined) {
+      setValidationErrors((prev) => {
+        const { embeddingFunctionUrl, ...rest } = prev
         return rest
       })
     }
@@ -176,23 +191,18 @@ export function DraftCollectionProvider({ children }: DraftCollectionProviderPro
     setIsCreating(true)
     try {
       const selectedEf = EMBEDDING_FUNCTIONS.find((ef) => ef.id === draftCollection.embeddingFunctionId) || DEFAULT_EF
-
-      // Parse dimension override
-      let dimension: number | undefined
-      if (draftCollection.dimensionOverride.trim()) {
-        const parsed = parseInt(draftCollection.dimensionOverride, 10)
-        if (!isNaN(parsed) && parsed > 0) {
-          dimension = parsed
-        }
+      const urlError = validateEmbeddingFunctionUrl(selectedEf, draftCollection.embeddingFunctionUrl)
+      if (urlError) {
+        setValidationErrors({ embeddingFunctionUrl: urlError })
+        return
       }
 
       // Build params
       const params: Parameters<typeof createMutation.mutateAsync>[0] = {
         name: draftCollection.name.trim(),
-        embeddingFunction: {
-          type: selectedEf.type,
-          modelName: selectedEf.modelName,
-        },
+        embeddingFunction: buildEmbeddingFunctionOverride(selectedEf, {
+          url: draftCollection.embeddingFunctionUrl,
+        }),
       }
 
       // Add HNSW config if any non-default values are set

--- a/tests/unit/ipc-contract.test.ts
+++ b/tests/unit/ipc-contract.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   parseConnectionProfile,
+  parseCopyCollectionParams,
   parseCreateCollectionParams,
+  parseEmbeddingOverride,
   parseSearchDocumentsParams,
   validateExternalUrl,
 } from '../../electron/ipc-contract'
@@ -41,9 +43,47 @@ describe('ipc contract validators', () => {
     })
   })
 
+  it('preserves embedding function URL and account fields', () => {
+    expect(parseEmbeddingOverride({
+      type: 'huggingface-server',
+      modelName: 'custom',
+      url: 'https://embeddings.example.com',
+    })).toMatchObject({
+      type: 'huggingface-server',
+      modelName: 'custom',
+      url: 'https://embeddings.example.com',
+    })
+
+    expect(parseCreateCollectionParams({
+      name: 'docs',
+      embeddingFunction: {
+        type: 'ollama',
+        modelName: 'nomic-embed-text',
+        url: 'http://localhost:11434',
+      },
+    }).embeddingFunction).toMatchObject({
+      type: 'ollama',
+      modelName: 'nomic-embed-text',
+      url: 'http://localhost:11434',
+    })
+
+    expect(parseCopyCollectionParams({
+      sourceCollectionName: 'docs',
+      targetName: 'docs-copy',
+      regenerateEmbeddings: true,
+      embeddingFunction: {
+        type: 'cloudflare-worker-ai',
+        modelName: '@cf/baai/bge-base-en-v1.5',
+        accountId: 'account-123',
+      },
+    }).embeddingFunction).toMatchObject({
+      type: 'cloudflare-worker-ai',
+      accountId: 'account-123',
+    })
+  })
+
   it('only allows http and https external URLs', () => {
     expect(validateExternalUrl('https://trychroma.com/docs')).toBe('https://trychroma.com/docs')
     expect(() => validateExternalUrl('file:///etc/passwd')).toThrow(/http: or https:/)
   })
 })
-


### PR DESCRIPTION
## Summary

Fixes #37 by making custom embedding server URLs configurable wherever users choose client-side embedding functions.

## What changed

- Added shared embedding function helpers for URL-backed providers, URL validation, labels, placeholders, and IPC override construction.
- Added Server URL / URL inputs for HuggingFace Server and Ollama in both the document embedding override popover and the create/copy collection form.
- Preserved provider URL metadata when copying collections and compared effective URL config when deciding whether embeddings must be regenerated.
- Changed the collection dimension control into read-only informational text because Chroma infers/enforces dimensions from generated embeddings.
- Added IPC contract coverage to ensure embedding function URL and account fields are preserved.

## Root cause

The Electron service and IPC contract already accepted `embeddingFunction.url`, and HuggingFace Server requires it, but the renderer only submitted the static embedding preset value. For HuggingFace Server that preset URL was empty, and there was no UI to enter a custom URL.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm check`
- `pnpm test:smoke`

Note: smoke build logs still include existing Sentry invalid-token upload warnings, but the build and Playwright smoke test completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for embedding-function URL overrides when creating or copying collections.
  * Collection setup now shows the selected embedding dimension as read-only and can handle different embedding sizes.
  * Added a new seeded test collection with larger-dimension fixture data.

* **Bug Fixes**
  * Improved validation for embedding-function URLs, with clearer errors and disabled actions when the URL is invalid.
  * Copying or saving collections now preserves the configured embedding-function URL where applicable.

* **Documentation**
  * Expanded seed-data docs to explain what local test database commands insert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->